### PR TITLE
fix: fixed compilation issues with darwin-x64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,10 @@ jobs:
               npm run build -- --target x86_64-unknown-linux-musl --abi linux-x64-musl
           - os: windows-latest
             abi: win32-x64-msvc
-          - os: macos-latest
+          - os: macos-13
             abi: darwin-x64
+          - os: macos-latest
+            abi: darwin-arm64
 
           # cross compile
           # windows. Note swc plugins is not supported on ia32 and arm64
@@ -57,10 +59,10 @@ jobs:
             target: aarch64-unknown-linux-gnu
             zig: true
           # macos
-          - os: macos-latest
-            abi: darwin-arm64
-            target: aarch64-apple-darwin
-            zig: false
+          # - os: macos-latest
+          #   abi: darwin-arm64
+          #   target: aarch64-apple-darwin
+          #   zig: false
           # - os: ubuntu-latest
           #   abi: darwin-x64
           #   target: x86_64-apple-darwin


### PR DESCRIPTION
![image](https://github.com/farm-fe/rust-plugin-example/assets/50993231/dc09b3c3-a45d-4c11-a879-67838340e4d2)

使用默认 macos 最新编译出来的架构是 arm 架构的 参考 farm 的 workflow 修改插件的编译规则